### PR TITLE
Psych compatibility

### DIFF
--- a/hoe-gemspec2.gemspec
+++ b/hoe-gemspec2.gemspec
@@ -2,50 +2,43 @@
 # stub: hoe-gemspec2 1.2.0 ruby lib
 
 Gem::Specification.new do |s|
-  s.name = "hoe-gemspec2"
+  s.name = "hoe-gemspec2".freeze
   s.version = "1.2.0"
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.require_paths = ["lib"]
-  s.authors = ["raggi"]
-  s.date = "2014-07-18"
-  s.description = "Adds support for generation of gemspec files to Hoe. By default, excludes the\nsigning key and certificate chain. Use <tt>rake gemspec:full</tt> to include\nthe signing key and certificate chain."
-  s.email = ["raggi@rubyforge.org"]
-  s.extra_rdoc_files = ["CHANGELOG.rdoc", "Manifest.txt", "README.rdoc"]
-  s.files = ["CHANGELOG.rdoc", "Manifest.txt", "README.rdoc", "Rakefile", "lib/hoe/gemspec2.rb"]
-  s.homepage = "http://rubygems.org/gems/hoe-gemspec2"
-  s.licenses = ["MIT"]
-  s.rdoc_options = ["--main", "README.rdoc"]
-  s.rubygems_version = "2.2.1"
-  s.summary = "Adds support for generation of gemspec files to Hoe"
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.metadata = { "homepage_uri" => "http://rubygems.org/gems/hoe-gemspec2" } if s.respond_to? :metadata=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["raggi".freeze]
+  s.date = "2022-03-24"
+  s.description = "Adds support for generation of gemspec files to Hoe. By default, excludes the\nsigning key and certificate chain. Use <tt>rake gemspec:full</tt> to include\nthe signing key and certificate chain.".freeze
+  s.email = ["raggi@rubyforge.org".freeze]
+  s.extra_rdoc_files = ["CHANGELOG.rdoc".freeze, "Manifest.txt".freeze, "README.rdoc".freeze]
+  s.files = ["CHANGELOG.rdoc".freeze, "Manifest.txt".freeze, "README.rdoc".freeze, "Rakefile".freeze, "lib/hoe/gemspec2.rb".freeze]
+  s.homepage = "http://rubygems.org/gems/hoe-gemspec2".freeze
+  s.licenses = ["MIT".freeze]
+  s.rdoc_options = ["--main".freeze, "README.rdoc".freeze]
+  s.rubygems_version = "3.3.9".freeze
+  s.summary = "Adds support for generation of gemspec files to Hoe".freeze
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
+  end
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<hoe>, [">= 0"])
-      s.add_development_dependency(%q<minitest>, ["~> 5.3"])
-      s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
-      s.add_development_dependency(%q<hoe-doofus>, [">= 1.0"])
-      s.add_development_dependency(%q<hoe-seattlerb>, [">= 1.2"])
-      s.add_development_dependency(%q<hoe-git>, [">= 1.3"])
-      s.add_development_dependency(%q<hoe-gemspec2>, [">= 0"])
-    else
-      s.add_dependency(%q<hoe>, [">= 0"])
-      s.add_dependency(%q<minitest>, ["~> 5.3"])
-      s.add_dependency(%q<rdoc>, ["~> 4.0"])
-      s.add_dependency(%q<hoe-doofus>, [">= 1.0"])
-      s.add_dependency(%q<hoe-seattlerb>, [">= 1.2"])
-      s.add_dependency(%q<hoe-git>, [">= 1.3"])
-      s.add_dependency(%q<hoe-gemspec2>, [">= 0"])
-    end
+  if s.respond_to? :add_runtime_dependency then
+    s.add_runtime_dependency(%q<hoe>.freeze, [">= 0"])
+    s.add_development_dependency(%q<minitest>.freeze, ["~> 5.15"])
+    s.add_development_dependency(%q<hoe-doofus>.freeze, [">= 1.0"])
+    s.add_development_dependency(%q<hoe-seattlerb>.freeze, [">= 1.2"])
+    s.add_development_dependency(%q<hoe-git>.freeze, [">= 1.3"])
+    s.add_development_dependency(%q<hoe-gemspec2>.freeze, [">= 0"])
+    s.add_development_dependency(%q<rdoc>.freeze, [">= 4.0", "< 7"])
   else
-    s.add_dependency(%q<hoe>, [">= 0"])
-    s.add_dependency(%q<minitest>, ["~> 5.3"])
-    s.add_dependency(%q<rdoc>, ["~> 4.0"])
-    s.add_dependency(%q<hoe-doofus>, [">= 1.0"])
-    s.add_dependency(%q<hoe-seattlerb>, [">= 1.2"])
-    s.add_dependency(%q<hoe-git>, [">= 1.3"])
-    s.add_dependency(%q<hoe-gemspec2>, [">= 0"])
+    s.add_dependency(%q<hoe>.freeze, [">= 0"])
+    s.add_dependency(%q<minitest>.freeze, ["~> 5.15"])
+    s.add_dependency(%q<hoe-doofus>.freeze, [">= 1.0"])
+    s.add_dependency(%q<hoe-seattlerb>.freeze, [">= 1.2"])
+    s.add_dependency(%q<hoe-git>.freeze, [">= 1.3"])
+    s.add_dependency(%q<hoe-gemspec2>.freeze, [">= 0"])
+    s.add_dependency(%q<rdoc>.freeze, [">= 4.0", "< 7"])
   end
 end

--- a/hoe-gemspec2.gemspec
+++ b/hoe-gemspec2.gemspec
@@ -2,43 +2,50 @@
 # stub: hoe-gemspec2 1.2.0 ruby lib
 
 Gem::Specification.new do |s|
-  s.name = "hoe-gemspec2".freeze
+  s.name = "hoe-gemspec2"
   s.version = "1.2.0"
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
-  s.metadata = { "homepage_uri" => "http://rubygems.org/gems/hoe-gemspec2" } if s.respond_to? :metadata=
-  s.require_paths = ["lib".freeze]
-  s.authors = ["raggi".freeze]
-  s.date = "2022-03-24"
-  s.description = "Adds support for generation of gemspec files to Hoe. By default, excludes the\nsigning key and certificate chain. Use <tt>rake gemspec:full</tt> to include\nthe signing key and certificate chain.".freeze
-  s.email = ["raggi@rubyforge.org".freeze]
-  s.extra_rdoc_files = ["CHANGELOG.rdoc".freeze, "Manifest.txt".freeze, "README.rdoc".freeze]
-  s.files = ["CHANGELOG.rdoc".freeze, "Manifest.txt".freeze, "README.rdoc".freeze, "Rakefile".freeze, "lib/hoe/gemspec2.rb".freeze]
-  s.homepage = "http://rubygems.org/gems/hoe-gemspec2".freeze
-  s.licenses = ["MIT".freeze]
-  s.rdoc_options = ["--main".freeze, "README.rdoc".freeze]
-  s.rubygems_version = "3.3.9".freeze
-  s.summary = "Adds support for generation of gemspec files to Hoe".freeze
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib"]
+  s.authors = ["raggi"]
+  s.date = "2014-07-18"
+  s.description = "Adds support for generation of gemspec files to Hoe. By default, excludes the\nsigning key and certificate chain. Use <tt>rake gemspec:full</tt> to include\nthe signing key and certificate chain."
+  s.email = ["raggi@rubyforge.org"]
+  s.extra_rdoc_files = ["CHANGELOG.rdoc", "Manifest.txt", "README.rdoc"]
+  s.files = ["CHANGELOG.rdoc", "Manifest.txt", "README.rdoc", "Rakefile", "lib/hoe/gemspec2.rb"]
+  s.homepage = "http://rubygems.org/gems/hoe-gemspec2"
+  s.licenses = ["MIT"]
+  s.rdoc_options = ["--main", "README.rdoc"]
+  s.rubygems_version = "2.2.1"
+  s.summary = "Adds support for generation of gemspec files to Hoe"
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
-  end
 
-  if s.respond_to? :add_runtime_dependency then
-    s.add_runtime_dependency(%q<hoe>.freeze, [">= 0"])
-    s.add_development_dependency(%q<minitest>.freeze, ["~> 5.15"])
-    s.add_development_dependency(%q<hoe-doofus>.freeze, [">= 1.0"])
-    s.add_development_dependency(%q<hoe-seattlerb>.freeze, [">= 1.2"])
-    s.add_development_dependency(%q<hoe-git>.freeze, [">= 1.3"])
-    s.add_development_dependency(%q<hoe-gemspec2>.freeze, [">= 0"])
-    s.add_development_dependency(%q<rdoc>.freeze, [">= 4.0", "< 7"])
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<hoe>, [">= 0"])
+      s.add_development_dependency(%q<minitest>, ["~> 5.3"])
+      s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
+      s.add_development_dependency(%q<hoe-doofus>, [">= 1.0"])
+      s.add_development_dependency(%q<hoe-seattlerb>, [">= 1.2"])
+      s.add_development_dependency(%q<hoe-git>, [">= 1.3"])
+      s.add_development_dependency(%q<hoe-gemspec2>, [">= 0"])
+    else
+      s.add_dependency(%q<hoe>, [">= 0"])
+      s.add_dependency(%q<minitest>, ["~> 5.3"])
+      s.add_dependency(%q<rdoc>, ["~> 4.0"])
+      s.add_dependency(%q<hoe-doofus>, [">= 1.0"])
+      s.add_dependency(%q<hoe-seattlerb>, [">= 1.2"])
+      s.add_dependency(%q<hoe-git>, [">= 1.3"])
+      s.add_dependency(%q<hoe-gemspec2>, [">= 0"])
+    end
   else
-    s.add_dependency(%q<hoe>.freeze, [">= 0"])
-    s.add_dependency(%q<minitest>.freeze, ["~> 5.15"])
-    s.add_dependency(%q<hoe-doofus>.freeze, [">= 1.0"])
-    s.add_dependency(%q<hoe-seattlerb>.freeze, [">= 1.2"])
-    s.add_dependency(%q<hoe-git>.freeze, [">= 1.3"])
-    s.add_dependency(%q<hoe-gemspec2>.freeze, [">= 0"])
-    s.add_dependency(%q<rdoc>.freeze, [">= 4.0", "< 7"])
+    s.add_dependency(%q<hoe>, [">= 0"])
+    s.add_dependency(%q<minitest>, ["~> 5.3"])
+    s.add_dependency(%q<rdoc>, ["~> 4.0"])
+    s.add_dependency(%q<hoe-doofus>, [">= 1.0"])
+    s.add_dependency(%q<hoe-seattlerb>, [">= 1.2"])
+    s.add_dependency(%q<hoe-git>, [">= 1.3"])
+    s.add_dependency(%q<hoe-gemspec2>, [">= 0"])
   end
 end

--- a/lib/hoe/gemspec2.rb
+++ b/lib/hoe/gemspec2.rb
@@ -12,7 +12,24 @@ module Hoe::Gemspec2
 
     file gemspec => %w[clobber Manifest.txt] + spec.files do
       open(gemspec, 'w') { |f|
-        spec2 = YAML.load(YAML.dump(spec))
+        permitted_classes = %w[
+          Symbol Time Date Gem::Dependency Gem::Platform Gem::Requirement
+          Gem::Specification Gem::Version Gem::Version::Requirement
+          YAML::Syck::DefaultKey Syck::DefaultKey
+        ]
+        permitted_symbols = %w[development runtime]
+        spec2 = begin
+                  YAML.safe_load(
+                    YAML.dump(spec),
+                    permitted_classes: permitted_classes,
+                    permitted_symbols: permitted_symbols,
+                    aliases: true
+                  )
+                rescue
+                  YAML.safe_load(
+                    YAML.dump(spec), permitted_classes, permitted_symbols, true
+                  )
+                end
 
         unless @include_all
           [ :signing_key, :cert_chain ].each { |name|


### PR DESCRIPTION
Fixes compatibility issues with Psych.safe_load for all psych versions > 2. Also see https://github.com/halostatue/minitar/pull/40.